### PR TITLE
Library does not work when using certain addons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
 import { combineParameters } from "@storybook/client-api";
+import addons, { mockChannel } from '@storybook/addons';
 import type { Story, Meta, StoryContext } from "@storybook/vue3";
 import type { StoryFnVueReturnType, ContextedStory, GlobalConfig, StoriesWithPartialProps } from "./types";
 
 import decorateStory from "./decorateStory";
 
 let globalStorybookConfig: GlobalConfig = {};
+
+// Some addons use the channel api to communicate between manager/preview, and this is a client only feature, therefore we must mock it.
+addons.setChannel(mockChannel());
 
 export function setGlobalConfig(config: GlobalConfig) {
   globalStorybookConfig = config;


### PR DESCRIPTION
 **Describe the bug** 
When running `composeStories` in stories that have certain addons, such as storybook-addons-design, the tests break with the following error:
 
 ```shell
 Error: Uncaught [Error: Accessing non-existent addons channel, see https://storybook.js.org/basics/faq/#why-is-there-no-addons-channel]
 ```
 **Expected behavior** 
Addons channel should not present error in the tests

See [testing-react ](https://github.com/storybookjs/testing-react/pull/14) for a similar fix